### PR TITLE
Auto start

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,0 +1,8 @@
+# Install this by copy pasting it into the root crontab, which can be edited by:
+# $ sudo crontab -e
+
+# Replace auth token below.
+JOULIA_WEBSERVER_AUTHTOKEN=<insert_auth_token>
+JOULIA_WEBSERVER_HOST=joulia.io
+
+@reboot /home/pi/miniconda/envs/joulia-controller/bin/python /home/pi/joulia-controller/main.py

--- a/crontab
+++ b/crontab
@@ -5,4 +5,7 @@
 JOULIA_WEBSERVER_AUTHTOKEN=<insert_auth_token>
 JOULIA_WEBSERVER_HOST=joulia.io
 
+# TODO(willjschmitt): Try to activate the conda env in crontab with the
+# commented out line below.
+#@reboot source /home/pi/miniconda/bin/activate /home/pi/miniconda/envs/joulia-controller && python /home/pi/joulia-controller/main.py
 @reboot /home/pi/miniconda/envs/joulia-controller/bin/python /home/pi/joulia-controller/main.py

--- a/main.py
+++ b/main.py
@@ -196,4 +196,8 @@ def create_analog_reader():
 
 
 if __name__ == "__main__":
-    main()  # pragma: no cover
+    try:
+        main()  # pragma: no cover
+    except Exception as e:
+        LOGGER.exception(e)
+        raise e

--- a/main.py
+++ b/main.py
@@ -41,6 +41,11 @@ def main():
     """Main routine is for running as standalone controller on embedded
     hardware. Loads settings from module and env vars, and launches a
     controller instance."""
+    root_directory = os.path.dirname(os.path.realpath(__file__))
+    LOGGER.info('Changing working directory to the directory of this file: %s',
+                root_directory)
+    os.chdir(root_directory)
+
     LOGGER.info('Starting brewery.')
     http_client = JouliaHTTPClient("http://" + settings.HOST,
                                    auth_token=settings.AUTHTOKEN)


### PR DESCRIPTION
Adds code to a crontab and logging support for auto start on reboot. Logging will go to /var/log/joulia/joulia.log on the Pi, since crontab will make the script effectively headless.